### PR TITLE
feat(api): auth resource routes

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"path"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/manojnakp/scount/db"
+)
+
+// RegisterRequest is the JSON request body format
+// at the `/auth/register` endpoint.
+type RegisterRequest struct {
+	// /docs/RegisterRequest.schema.json
+	// Schema string `json:"$schema,omitempty"`
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+// Validate implements Validator on RegisterRequest.
+// Simply check non-empty.
+func (r RegisterRequest) Validate() error {
+	if r.Username == "" ||
+		r.Email == "" ||
+		r.Password == "" {
+		return errors.New("api: validation failed")
+	}
+	return nil
+}
+
+// RegisterResponse is the JSON response format
+// at the `auth/register` endpoint.
+type RegisterResponse struct {
+	// `/docs/RegisterResponse.schema.json`
+	Schema string `json:"$schema,omitempty"`
+	UserId string `json:"user_id"`
+}
+
+// AuthResource is http.Handler for all requests to `/auth`
+type AuthResource struct {
+	DB *db.Store
+}
+
+// Router constructs a new chi router for the auth resource.
+func (res AuthResource) Router() chi.Router {
+	r := chi.NewRouter()
+	r.With(BodyParser[RegisterRequest], Validware[RegisterRequest]).
+		Post("/register", func(w http.ResponseWriter, r *http.Request) {
+			body := r.Context().Value(BodyKey).(RegisterRequest)
+			uid := GenerateID()
+			// insert into db
+			err := res.DB.Users.Insert(r.Context(), db.User{
+				Uid:      uid,
+				Email:    body.Email,
+				Username: body.Username,
+				Password: body.Password,
+			})
+			// match error
+			switch {
+			case errors.Is(err, db.ErrInvalidData),
+				errors.Is(err, db.ErrSyntaxPrivilege):
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			case errors.Is(err, db.ErrConflict):
+				w.WriteHeader(http.StatusConflict)
+				return
+			case err != nil:
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			// newly created user resource at location
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Location", path.Join("/users/", uid))
+			w.WriteHeader(http.StatusOK)
+			// json response
+			_ = json.NewEncoder(w).Encode(RegisterResponse{
+				Schema: path.Join("/docs/", "RegisterResponse.schema.json"),
+				UserId: uid,
+			})
+		})
+	return r
+}
+
+// ServeHTTP implements http.Handler on AuthResource.
+func (res AuthResource) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	mux := res.Router()
+	mux.ServeHTTP(w, r)
+}

--- a/api/auth.go
+++ b/api/auth.go
@@ -45,6 +45,32 @@ type RegisterResponse struct {
 	UserId string `json:"user_id"`
 }
 
+// LoginRequest is the JSON request body format
+// at the `/auth/login` endpoint.
+type LoginRequest struct {
+	// /docs/LoginRequest.schema.json
+	// Schema string `json:"$schema,omitempty"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+// Validate implements Validator on LoginRequest.
+// Simply check non-empty.
+func (r LoginRequest) Validate() error {
+	if r.Email == "" || r.Password == "" {
+		return errors.New("api: validation failed")
+	}
+	return nil
+}
+
+// LoginResponse is the JSON response body format
+// at the `/auth/login` endpoint.
+type LoginResponse struct {
+	// `/docs/LoginResponse.schema.json`
+	Schema string `json:"$schema,omitempty"`
+	Token  string `json:"token"`
+}
+
 // AuthResource is http.Handler for all requests to `/auth`
 type AuthResource struct {
 	DB *db.Store
@@ -55,6 +81,8 @@ func (res AuthResource) Router() chi.Router {
 	r := chi.NewRouter()
 	r.With(BodyParser[RegisterRequest], Validware[RegisterRequest]).
 		Post("/register", res.register)
+	r.With(BodyParser[LoginRequest], Validware[LoginRequest]).
+		Post("/login", res.login)
 	return r
 }
 
@@ -102,5 +130,46 @@ func (res AuthResource) register(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(RegisterResponse{
 		Schema: path.Join("/docs/", "RegisterResponse.schema.json"),
 		UserId: uid,
+	})
+}
+
+// login handles user sign in.
+func (res AuthResource) login(w http.ResponseWriter, r *http.Request) {
+	body := r.Context().Value(BodyKey).(LoginRequest)
+	user, err := res.DB.Users.FindByEmail(r.Context(), body.Email)
+	switch {
+	case errors.Is(err, db.ErrNoRows): // not found
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		return
+	case err != nil: // db error
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	buf, err := base64.StdEncoding.DecodeString(user.Password)
+	if err != nil { // failed
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	err = bcrypt.CompareHashAndPassword(buf, []byte(body.Password))
+	switch {
+	// invalid password provided by client in request body
+	case errors.Is(err, bcrypt.ErrMismatchedHashAndPassword):
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		return
+	case err != nil: // server error
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	token, err := GenerateToken(user.Uid)
+	if err != nil { // base64 failed to decode
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	// json response
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(LoginResponse{
+		Schema: path.Join("/docs/", "LoginResponse.schema.json"),
+		Token:  string(token),
 	})
 }

--- a/docs/LoginRequest.schema.json
+++ b/docs/LoginRequest.schema.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "email": {
+            "type": "string",
+            "format": "email"
+        },
+        "password": {
+            "type": "string"
+        }
+    },
+    "examples": [
+        {
+            "email": "john@jdoe.net",
+            "password": "iamjd0e"
+        },
+        {
+            "email": "alex@example.org",
+            "password": "keepitsecret"
+        }
+    ]
+}

--- a/docs/LoginResponse.schema.json
+++ b/docs/LoginResponse.schema.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "token": {
+            "type": "string"
+        }
+    },
+    "examples": [
+        {
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjEyNTc4OTc2MDAsInN1YiI6IjJrajNlOXBzOHVxOTM0cGgifQ.n0_har5M6WYK5HmSsQarZbJp5A5dNrvKfbINA6eYEQs"
+        },
+        {
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjEyNTc4OTc2MDAsInN1YiI6IjUzNmo1a2hnNjRqaDYzMmkifQ.qgrsFe8HZ2m02oOYgZJbqBknI65BBYWw71cvGyr7QRQ"
+        }
+    ]
+}

--- a/docs/PasswordChange.schema.json
+++ b/docs/PasswordChange.schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "old": {
+            "type": "string"
+        },
+        "new": {
+            "type": "string"
+        }
+    },
+    "examples": [
+        {
+            "old": "iamjd0e",
+            "new": "jd0esecret"
+        },
+        {
+            "old": "keepitsecret",
+            "new": "iamal3x"
+        }
+    ]
+}

--- a/docs/RegisterRequest.schema.json
+++ b/docs/RegisterRequest.schema.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "username": {
+            "type": "string"
+        },
+        "email": {
+            "type": "string",
+            "format": "email"
+        },
+        "password": {
+            "type": "string"
+        }
+    },
+    "examples": [
+        {
+            "username": "John doe",
+            "email": "john@jdoe.net",
+            "password": "iamjd0e"
+        },
+        {
+            "username": "alex",
+            "email": "alex@example.org",
+            "password": "keepitsecret"
+        }
+    ]
+}

--- a/docs/RegisterResponse.schema.json
+++ b/docs/RegisterResponse.schema.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "user_id": {
+            "type": "string"
+        }
+    },
+    "examples": [
+        {
+            "user_id": "2kj3e9ps8uq934ph"
+        },
+        {
+            "user_id": "536j5khg64jh632i"
+        }
+    ]
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -78,6 +78,59 @@
                     }
                 }
             }
+        },
+        "/auth/login": {
+            "post": {
+                "operationId": "LoginUser",
+                "tags": ["auth"],
+                "summary": "Sign in a user",
+                "description": "User authenticates oneself into the SCount API using valid credentials.",
+                "requestBody": {
+                    "description": "User credentials for sign in",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "./LoginRequest.schema.json"
+                            },
+                            "example": {
+                                "email": "john@jdoe.net",
+                                "password": "iamjd0e"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Sign in successfull, use this token to authenticate your requests.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "./LoginResponse.schema.json"
+                                },
+                                "example": {
+                                    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjEyNTc4OTc2MDAsInN1YiI6IjJrajNlOXBzOHVxOTM0cGgifQ.n0_har5M6WYK5HmSsQarZbJp5A5dNrvKfbINA6eYEQs"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "415": {
+                        "$ref": "#/components/responses/UnsupportedMediaType"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/UnprocessableContent"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultResponse"
+                    }
+                }
+            }
         }
     },
     "components": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,10 +7,102 @@
     },
     "servers": [
         {
-            "url": "..",
+            "url": "/.",
             "description": "api server hosted at root path"
         }
     ],
-    "paths": {},
-    "components": {}
+    "paths": {
+        "/auth/register": {
+            "post": {
+                "operationId": "RegisterUser",
+                "tags": ["auth"],
+                "summary": "Sign up a new user",
+                "description": "Send user information and password to sign up for SCount and obtain a unique userid",
+                "requestBody": {
+                    "description": "User information and new set of credentials for sign up",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "./RegisterRequest.schema.json"
+                            },
+                            "example": {
+                                "username": "John doe",
+                                "email": "john@jdoe.net",
+                                "password": "iamjd0e"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Sign up successfull, here's your user id.",
+                        "headers": {
+                            "location": {
+                                "description": "URI of the user resource for the newly signed up user",
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "example": "/users/2kj3e9ps8uq934ph"
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "./RegisterResponse.schema.json"
+                                },
+                                "example": {
+                                    "user_id": "2kj3e9ps8uq934ph"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "409": {
+                        "$ref": "#/components/responses/Conflict"
+                    },
+                    "415": {
+                        "$ref": "#/components/responses/UnsupportedMediaType"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/UnprocessableContent"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultResponse"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "responses": {
+            "DefaultResponse": {
+                "description": "Could not serve the request due to certain issues."
+            },
+            "BadRequest": {
+                "description": "Cannot serve content because of malformed request body or syntax"
+            },
+            "Conflict": {
+                "description": "The request conflicts or causes a conflict (after requested operation) with the state of server."
+            },
+            "UnsupportedMediaType": {
+                "description": "The media format of the requested data is not supported by the server, so the server is rejecting the request."
+            },
+            "UnprocessableContent": {
+                "description": "The request was well-formed but was unable to be followed due to semantic errorsor validation failure."
+            },
+            "InternalServerError": {
+                "description": "The server has encountered a situation it does not know how to handle."
+            }
+        }
+    },
+    "tags": [
+        {"name": "auth", "description": "Operations related to authentication"}
+  ]
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -153,6 +153,14 @@
             "InternalServerError": {
                 "description": "The server has encountered a situation it does not know how to handle."
             }
+        },
+        "securitySchemes": {
+            "token": {
+                "description": "Token based authentication using JWT in 'Authorization' header",
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT"
+            }
         }
     },
     "tags": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -131,6 +131,58 @@
                     }
                 }
             }
+        },
+        "/auth/change": {
+            "post": {
+                "operationId": "ChangePassword",
+                "tags": ["auth"],
+                "summary": "Change user password",
+                "description": "Request for updating the set of credentials used for authenticating the user.",
+                "security": [
+                    {"token": []}
+                ],
+                "requestBody": {
+                    "description": "Old and new set of credentials for update.",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "./PasswordChange.schema.json"
+                            },
+                            "example": {
+                                "old": "iamjd0e",
+                                "new": "jd0esecret"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "Password change successfull"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/Unauthorized"
+                    },
+                    "409": {
+                        "$ref": "#/components/responses/Conflict"
+                    },
+                    "415": {
+                        "$ref": "#/components/responses/UnsupportedMediaType"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/UnprocessableContent"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/DefaultResponse"
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -140,6 +192,9 @@
             },
             "BadRequest": {
                 "description": "Cannot serve content because of malformed request body or syntax"
+            },
+            "Unauthorized": {
+                "description": "User is not authenticated, the resource is protected."
             },
             "Conflict": {
                 "description": "The request conflicts or causes a conflict (after requested operation) with the state of server."

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/lestrrat-go/jwx/v2 v2.0.12
 	github.com/lib/pq v1.10.9
+	golang.org/x/crypto v0.12.0
 	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
 )
 
@@ -18,6 +19,5 @@ require (
 	github.com/lestrrat-go/iter v1.0.2 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
-	golang.org/x/crypto v0.12.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	r := chi.NewRouter()
 	r.Mount("/docs/", DocHandler{}.Router())
 	r.Handle("/docs", http.RedirectHandler("/docs/", http.StatusMovedPermanently))
-	_ = store
+	r.Mount("/auth", api.AuthResource{DB: store}.Router())
 	r.HandleFunc("/health", HealthCheck)
 	_ = http.ListenAndServe(":8080", r)
 }


### PR DESCRIPTION

- [x] `/auth/register`
    - [x] openapi documentation for register
    - [x] register request and response schema
    - [x] serve POST on the route (db insert)
- [x] `/auth/login`
    - [x] openapi documentation for login
    - [x] login request and response schema
    - [x] serve POST on the route (token)
- [x] `/auth/change`
    - [x] openapi documentation for password change
    - [x] change request schema (no response)
    - [x] serve POST on the route (db update)
