### PR TITLE
feat: iterator for collections.List methods

### DIFF
--- a/api/users.go
+++ b/api/users.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -80,11 +81,13 @@ func (res UserResource) fetch(w http.ResponseWriter, r *http.Request) {
 func (res UserResource) list(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseForm() // populates url query parameters to r.Form.
 	if err != nil {
+		log.Println(err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	query, err := ParseUserParams(r.Form)
 	if err != nil {
+		log.Println(err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -103,6 +106,7 @@ func (res UserResource) list(w http.ResponseWriter, r *http.Request) {
 	// database call
 	users, err := res.DB.Users.Find(r.Context(), filter, projector)
 	if err != nil {
+		log.Println(err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/api/users.go
+++ b/api/users.go
@@ -111,15 +111,22 @@ func (res UserResource) list(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// build response collection
-	total := users.Total
-	list := make([]UserInfo, 0, len(users.Data))
-	for _, x := range users.Data {
+	list := make([]UserInfo, 0)
+	users.Iterator(func(u db.User) bool {
 		list = append(list, UserInfo{
-			Id:    x.Uid,
-			Email: x.Email,
-			Name:  x.Username,
+			Id:    u.Uid,
+			Email: u.Email,
+			Name:  u.Username,
 		})
+		return true
+	})
+	err = users.Err()
+	if err != nil {
+		log.Println(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
+	total := users.Total()
 	// link header
 	if total > 0 {
 		header := res.linkHeader(r.URL.Query(), query.Size, 0, total/query.Size)

--- a/db/postgres/members.go
+++ b/db/postgres/members.go
@@ -120,7 +120,10 @@ func (colln MemberCollection) UpdateOne(context.Context, *db.MemberId, *db.Membe
 }
 
 // FindOne fetches member from colln by id.
-func (colln MemberCollection) FindOne(ctx context.Context, id *db.MemberId) (m db.Member, err error) {
+func (colln MemberCollection) FindOne(
+	ctx context.Context,
+	id *db.MemberId,
+) (m db.Member, err error) {
 	if id == nil {
 		err = db.ErrNil
 		return
@@ -143,13 +146,13 @@ func (colln MemberCollection) Find(
 	ctx context.Context,
 	filter *db.MemberFilter,
 	projector *db.Projector,
-) (list db.List[db.Member], err error) {
+) (list *db.Iterable[db.Member], err error) {
 	args := colln.buildArgs(filter)
 	counter, finder, err := colln.buildSelectQuery(projector)
 	if err != nil {
 		return
 	}
-	iterator := func(yield func(db.Member) bool) (int, error) {
+	iterable := func(yield func(db.Member) bool) (int, error) {
 		return Tx[int](ctx, colln.DB, func(tx *sql.Tx) (int, error) {
 			return queryData[db.Member]{
 				context: ctx,
@@ -161,8 +164,7 @@ func (colln MemberCollection) Find(
 			}.iterator(yield)
 		})
 	}
-	iterable := db.NewIterable(iterator)
-	return db.ListFromIterable(iterable)
+	return db.NewIterable(iterable), nil
 }
 
 // scanOne scans one member from rows and returns associated data.

--- a/db/postgres/scounts.go
+++ b/db/postgres/scounts.go
@@ -48,18 +48,28 @@ WHERE sid = $1;
 var ScountSelectTemplate = template.Must(template.New("scount-select").
 	Funcs(template.FuncMap{"join": JoinSorter}).
 	Parse(`
-SELECT DISTINCT sid, owner, title, description,
-count(*) OVER () AS total
-FROM scounts NATURAL JOIN members
-WHERE ($1 OR sid = $2)
-AND ($3 OR uid = $4)
-AND ($5 OR owner = $6)
-AND ($7 OR title ILIKE $8)
-ORDER BY {{ join .Order "sid, uid" }}
-{{ with .Paging }}
-	LIMIT {{ .Limit }}
-	OFFSET {{ .Offset }}
-{{ end }};
+{{ define "filter" }}
+	FROM scounts NATURAL JOIN members
+	WHERE ($1 OR sid = $2)
+	AND ($3 OR uid = $4)
+	AND ($5 OR owner = $6)
+	AND ($7 OR title ILIKE $8)
+	ORDER BY {{ join .Order "sid, uid" }}
+{{ end }}
+
+{{ define "find" }}
+	SELECT DISTINCT sid, owner, title, description,
+	{{ template "filter" }}
+	{{ with .Paging }}
+		LIMIT {{ .Limit }}
+		OFFSET {{ .Offset }}
+	{{ end }};
+{{ end }}
+
+{{ define "count" }}
+	SELECT count(*) AS total
+	{{ template "filter" }};
+{{ end }}
 `))
 
 // ScountCollection provides a convenient way to interact with `scounts` table.
@@ -215,59 +225,74 @@ func (colln ScountCollection) Find(
 	filter *db.ScountFilter,
 	projector *db.Projector,
 ) (list db.List[db.Scount], err error) {
-	// pointer validity check
-	if filter == nil {
-		filter = new(db.ScountFilter)
-	}
-	if projector == nil {
-		projector = new(db.Projector)
-	}
-	// construct query from template
-	query, args, err := colln.buildSelectQuery(filter, projector)
+	args := colln.buildArgs(filter)
+	counter, finder, err := colln.buildSelectQuery(projector)
 	if err != nil {
 		return
 	}
-	// execute query
-	rows, err := colln.DB.QueryContext(ctx, query, args...)
+	iterator := func(yield func(db.Scount) bool) (int, error) {
+		return Tx[int](ctx, colln.DB, func(tx *sql.Tx) (int, error) {
+			return queryData[db.Scount]{
+				context: ctx,
+				sqldb:   tx,
+				counter: counter,
+				finder:  finder,
+				args:    args,
+				scanner: colln.scanOne,
+			}.iterator(yield)
+		})
+	}
+	iterable := db.NewIterable[db.Scount](iterator)
+	return db.ListFromIterable(iterable)
+}
+
+// scanOne scans one scount from rows and returns associated data.
+func (colln ScountCollection) scanOne(rows *sql.Rows) (s db.Scount, err error) {
+	var scount db.Scount
+	err = rows.Scan(&scount.Sid, &scount.Owner, &scount.Title, &scount.Description)
 	if err != nil {
-		err = Error(err)
 		return
 	}
-	defer rows.Close()
-	var scounts []db.Scount
-	var total int
-	// scan through the rows
-	for rows.Next() {
-		var s db.Scount
-		err = rows.Scan(&s.Sid, &s.Owner, &s.Title, &s.Description)
-		if err != nil {
-			return
-		}
-		scounts = append(scounts, s)
-	}
-	if err = rows.Err(); err != nil {
-		return
-	}
-	return db.List[db.Scount]{Data: scounts, Total: total}, nil
+	return scount, nil
 }
 
 // buildSelectQuery constructs scount select query using
 // provided filter, projector and SCountSelectTemplate.
-func (colln ScountCollection) buildSelectQuery(
-	filter *db.ScountFilter,
-	projector *db.Projector,
-) (string, []any, error) {
+func (colln ScountCollection) buildSelectQuery(projector *db.Projector) (string, string, error) {
 	// TODO: projector.Order[i] NOT IN db.ScountAllowedCols -> db.ErrInvalidColumn
-	args := make([]any, 0)
-	// WHERE clause
-	// construct
+	if projector == nil {
+		projector = new(db.Projector)
+	}
+	// construct count query
 	buf := new(bytes.Buffer)
-	err := ScountSelectTemplate.Execute(buf, projector)
+	err := ScountSelectTemplate.ExecuteTemplate(buf, "count", projector)
 	if err != nil {
 		log.Println("tmpl exec scount-select: ", err)
-		return "", nil, err
+		return "", "", err
 	}
-	return buf.String(), args, nil
+	counter := buf.String()
+	// construct find query
+	buf.Reset()
+	err = ScountSelectTemplate.ExecuteTemplate(buf, "find", projector)
+	if err != nil {
+		return "", "", err
+	}
+	finder := buf.String()
+	return counter, finder, nil
+}
+
+// buildArgs constructs sql dollar argument values for executing the query.
+func (colln ScountCollection) buildArgs(filter *db.ScountFilter) []any {
+	if filter == nil {
+		filter = new(db.ScountFilter)
+	}
+	args := make([]any, 0)
+	// WHERE clause
+	args = append(args, filter.Sid == "", filter.Sid)
+	args = append(args, filter.Uid == "", filter.Uid)
+	args = append(args, filter.Owner == "", filter.Owner)
+	args = append(args, filter.Title == "", filter.Title)
+	return args
 }
 
 // compile-time assertion

--- a/db/postgres/scounts.go
+++ b/db/postgres/scounts.go
@@ -159,7 +159,10 @@ func (colln ScountCollection) buildUpdateQuery(
 }
 
 // FindOne fetches scount from colln by id.
-func (colln ScountCollection) FindOne(ctx context.Context, id *db.ScountId) (s db.Scount, err error) {
+func (colln ScountCollection) FindOne(
+	ctx context.Context,
+	id *db.ScountId,
+) (s db.Scount, err error) {
 	if id == nil {
 		err = db.ErrNil
 		return
@@ -224,7 +227,7 @@ func (colln ScountCollection) Find(
 	ctx context.Context,
 	filter *db.ScountFilter,
 	projector *db.Projector,
-) (list db.List[db.Scount], err error) {
+) (list *db.Iterable[db.Scount], err error) {
 	args := colln.buildArgs(filter)
 	counter, finder, err := colln.buildSelectQuery(projector)
 	if err != nil {
@@ -242,8 +245,7 @@ func (colln ScountCollection) Find(
 			}.iterator(yield)
 		})
 	}
-	iterable := db.NewIterable[db.Scount](iterator)
-	return db.ListFromIterable(iterable)
+	return db.NewIterable[db.Scount](iterator), nil
 }
 
 // scanOne scans one scount from rows and returns associated data.

--- a/db/postgres/store.go
+++ b/db/postgres/store.go
@@ -140,7 +140,7 @@ type queryData[T any] struct {
 // a closure (avoid callback hell).
 func (data queryData[T]) iterator(yield func(T) bool) (int, error) {
 	var total int
-	err := data.sqldb.QueryRowContext(data.context, data.counter, data.args).
+	err := data.sqldb.QueryRowContext(data.context, data.counter, data.args...).
 		Scan(&total)
 	if err != nil {
 		return 0, err

--- a/db/postgres/users.go
+++ b/db/postgres/users.go
@@ -276,7 +276,7 @@ func (colln UserCollection) Find(
 	ctx context.Context,
 	filter *db.UserFilter,
 	projector *db.Projector,
-) (list db.List[db.User], err error) {
+) (list *db.Iterable[db.User], err error) {
 	args := colln.buildArgs(filter)
 	counter, finder, err := colln.buildSelectQuery(projector)
 	if err != nil {
@@ -294,8 +294,7 @@ func (colln UserCollection) Find(
 			}.iterator(yield)
 		})
 	}
-	iterable := db.NewIterable[db.User](iterator)
-	return db.ListFromIterable(iterable)
+	return db.NewIterable[db.User](iterator), nil
 }
 
 // scanOne scans one user from rows and returns associated data.

--- a/db/postgres/users.go
+++ b/db/postgres/users.go
@@ -60,12 +60,16 @@ var UserSelectTemplate = template.Must(template.New("user-select").
 	WHERE ($1 OR uid = $2)
 	AND ($3 OR email = $4)
 	AND ($5 OR username ILIKE $6)
+{{ end }}
+
+{{ define "sort" }}
 	ORDER BY {{ join .Order "uid" }}
 {{ end }}
 
 {{ define "find" }}
-	SELECT DISTINCT uid, email, username, password,
-	{{ template "filter"}}
+	SELECT DISTINCT uid, email, username, password
+	{{ template "filter" }}
+	{{ template "sort" }}
 	{{ with .Paging }}
 		LIMIT {{ .Limit }}
 		OFFSET {{ .Offset }}
@@ -74,7 +78,9 @@ var UserSelectTemplate = template.Must(template.New("user-select").
 
 {{ define "count" }}
 	SELECT count(*) AS total
-	{{ template "filter" }};
+	{{ template "filter" }}
+	GROUP BY uid
+	{{ template "sort" }};
 {{ end }}
 `))
 

--- a/db/postgres/users.go
+++ b/db/postgres/users.go
@@ -55,17 +55,27 @@ WHERE uid = $1;
 var UserSelectTemplate = template.Must(template.New("user-select").
 	Funcs(template.FuncMap{"join": JoinSorter}).
 	Parse(`
-SELECT DISTINCT uid, email, username, password,
-count(*) OVER () AS total
-FROM users
-WHERE ($1 OR uid = $2)
-AND ($3 OR email = $4)
-AND ($5 OR username ILIKE $6)
-ORDER BY {{ join .Order "uid" }}
-{{ with .Paging }}
-	LIMIT {{ .Limit }}
-	OFFSET {{ .Offset }}
-{{ end }};
+{{ define "filter" }}
+	FROM users
+	WHERE ($1 OR uid = $2)
+	AND ($3 OR email = $4)
+	AND ($5 OR username ILIKE $6)
+	ORDER BY {{ join .Order "uid" }}
+{{ end }}
+
+{{ define "find" }}
+	SELECT DISTINCT uid, email, username, password,
+	{{ template "filter"}}
+	{{ with .Paging }}
+		LIMIT {{ .Limit }}
+		OFFSET {{ .Offset }}
+	{{ end }};
+{{ end }}
+
+{{ define "count" }}
+	SELECT count(*) AS total
+	{{ template "filter" }};
+{{ end }}
 `))
 
 // UserCollection provides a convenient way to interact with `users` table.
@@ -261,68 +271,79 @@ func (colln UserCollection) Find(
 	filter *db.UserFilter,
 	projector *db.Projector,
 ) (list db.List[db.User], err error) {
-	// pointer validity check
-	if filter == nil {
-		filter = new(db.UserFilter)
-	}
-	if projector == nil {
-		projector = new(db.Projector)
-	}
-	// construct query from template
-	query, args, err := colln.buildSelectQuery(filter, projector)
+	args := colln.buildArgs(filter)
+	counter, finder, err := colln.buildSelectQuery(projector)
 	if err != nil {
 		return
 	}
-	// execute query
-	rows, err := colln.DB.QueryContext(ctx, query, args...)
+	iterator := func(yield func(db.User) bool) (int, error) {
+		return Tx[int](ctx, colln.DB, func(tx *sql.Tx) (int, error) {
+			return queryData[db.User]{
+				context: ctx,
+				sqldb:   tx,
+				counter: counter,
+				finder:  finder,
+				args:    args,
+				scanner: colln.scanOne,
+			}.iterator(yield)
+		})
+	}
+	iterable := db.NewIterable[db.User](iterator)
+	return db.ListFromIterable(iterable)
+}
+
+// scanOne scans one user from rows and returns associated data.
+func (colln UserCollection) scanOne(rows *sql.Rows) (u db.User, err error) {
+	var user db.User
+	var password string
+	err = rows.Scan(&user.Uid, &user.Email, &user.Username, &password)
 	if err != nil {
-		err = Error(err)
 		return
 	}
-	defer rows.Close()
-	var users []db.User
-	var total int
-	// scan through the rows
-	for rows.Next() {
-		var u db.User
-		var password string
-		err = rows.Scan(&u.Uid, &u.Email, &u.Username, &password, &total)
-		if err != nil {
-			return
-		}
-		u.Password, err = base64.StdEncoding.DecodeString(password)
-		if err != nil {
-			err = internal.Error{Pretty: db.ErrEncoding, Err: err}
-			return
-		}
-		users = append(users, u)
-	}
-	if err = rows.Err(); err != nil {
+	user.Password, err = base64.StdEncoding.DecodeString(password)
+	if err != nil {
+		err = internal.Error{Pretty: db.ErrEncoding, Err: err}
 		return
 	}
-	return db.List[db.User]{Data: users, Total: total}, nil
+	return user, err
 }
 
 // buildSelectQuery constructs user select query using
 // provided filter, projector and UserSelectTemplate.
-func (colln UserCollection) buildSelectQuery(
-	filter *db.UserFilter,
-	projector *db.Projector,
-) (string, []any, error) {
+func (colln UserCollection) buildSelectQuery(projector *db.Projector) (string, string, error) {
 	// TODO: projector.Order[i] NOT IN db.UserAllowedCols -> db.ErrInvalidColumn
+	if projector == nil {
+		projector = new(db.Projector)
+	}
+	// construct count query
+	buf := new(bytes.Buffer)
+	err := UserSelectTemplate.ExecuteTemplate(buf, "count", projector)
+	if err != nil {
+		return "", "", err
+	}
+	counter := buf.String()
+	// construct find query
+	buf.Reset()
+	err = UserSelectTemplate.ExecuteTemplate(buf, "find", projector)
+	if err != nil {
+		return "", "", err
+	}
+	finder := buf.String()
+	return counter, finder, nil
+}
+
+// buildArgs constructs sql dollar argument values for executing the query.
+func (colln UserCollection) buildArgs(filter *db.UserFilter) []any {
+	// pointer validity check
+	if filter == nil {
+		filter = new(db.UserFilter)
+	}
 	args := make([]any, 0)
 	// WHERE clause
 	args = append(args, filter.Uid == "", filter.Uid)
 	args = append(args, filter.Email == "", filter.Email)
 	args = append(args, filter.Username == "", filter.Username)
-	// construct
-	buf := new(bytes.Buffer)
-	err := UserSelectTemplate.Execute(buf, projector)
-	if err != nil {
-		log.Println("tmpl exec user-select: ", err)
-		return "", nil, err
-	}
-	return buf.String(), args, nil
+	return args
 }
 
 // compile-time assertion

--- a/db/store.go
+++ b/db/store.go
@@ -65,15 +65,6 @@ type Sorter struct {
 	Desc   bool   // descending order
 }
 
-// List is a generic list of items.
-//
-// Deprecated: using entire slice of items is impractical. Switch
-// to Iterable instead.
-type List[T any] struct {
-	Data  []T
-	Total int
-}
-
 // Iterable is a list of generic items being iterable. Iteration
 // is provided via a closure function.
 //
@@ -115,23 +106,6 @@ func NewIterable[T any](iterator func(yield func(T) bool) (int, error)) *Iterabl
 	return &Iterable[T]{
 		iterator: iterator,
 	}
-}
-
-// ListFromIterable allows forward migration for iterable syntax.
-//
-// Deprecated: Used to provide migration from List. List is no longer supported.
-func ListFromIterable[T any](iterable *Iterable[T]) (list List[T], err error) {
-	var data []T
-	iterable.Iterator(func(t T) bool {
-		data = append(data, t)
-		return true
-	})
-	err = iterable.Err()
-	if err != nil {
-		return
-	}
-	total := iterable.Total()
-	return List[T]{Data: data, Total: total}, nil
 }
 
 // Err reports any errors that occurred during the iteration over

--- a/db/store.go
+++ b/db/store.go
@@ -40,7 +40,7 @@ type Collection[Item, Filter, Updater, Id any] interface {
 	UpdateOne(context.Context, *Id, *Updater) error
 	// Find fetches all the records that match the given filter and projects
 	// them as a list. If no records match, then empty list.
-	Find(context.Context, *Filter, *Projector) (List[Item], error)
+	Find(context.Context, *Filter, *Projector) (*Iterable[Item], error)
 	// FindOne fetches exactly one matching record. If no such record exist
 	// in the database, then ErrNoRows.
 	FindOne(ctx context.Context, id *Id) (Item, error)
@@ -66,7 +66,9 @@ type Sorter struct {
 }
 
 // List is a generic list of items.
-// TODO: convert into iterator.
+//
+// Deprecated: using entire slice of items is impractical. Switch
+// to Iterable instead.
 type List[T any] struct {
 	Data  []T
 	Total int
@@ -116,6 +118,8 @@ func NewIterable[T any](iterator func(yield func(T) bool) (int, error)) *Iterabl
 }
 
 // ListFromIterable allows forward migration for iterable syntax.
+//
+// Deprecated: Used to provide migration from List. List is no longer supported.
 func ListFromIterable[T any](iterable *Iterable[T]) (list List[T], err error) {
 	var data []T
 	iterable.Iterator(func(t T) bool {


### PR DESCRIPTION
Intermediate slices just eat up memory. Stream from the database directly using an iterator.
From go 1.22 `GOEXPERIMENT=range`, push iterators may get range syntax. So go with such an API.